### PR TITLE
write citation for rmini

### DIFF
--- a/18-renferences.Rmd
+++ b/18-renferences.Rmd
@@ -2,7 +2,7 @@
 
 ```{r include=FALSE}
 knitr::write_bib(
-  .packages(),
+  c(.packages(), 'rmini'),
   'packages.bib'
 )
 ```


### PR DESCRIPTION
avoid the warning of

> pandoc-citeproc: reference R-rmini not found

like https://github.com/rstudio/bookdown-demo/blob/4e34630d5187848c3b260cdeb8ed8bd8402c998d/index.Rmd#L33-L35